### PR TITLE
Fix the unsigned integer range

### DIFF
--- a/src/content/chapter-2/ch-02-02-primitive-data-types.mdx
+++ b/src/content/chapter-2/ch-02-02-primitive-data-types.mdx
@@ -24,7 +24,7 @@ The size (or bit width) of an integer type dictates the range of values it can h
 
 The range of values a type can store depends on its size (*n* bits) and whether it's signed or unsigned:
 * Signed variants store numbers from -(2<sup>n - 1</sup>) to 2<sup>n - 1</sup> - 1, inclusive.
-* Unsigned variants store numbers from 0 to 2<sup>n - 1</sup> - 1, inclusive.
+* Unsigned variants store numbers from 0 to 2<sup>n</sup> - 1, inclusive.
 
 For example, an `i8` can store values from -128 to 127, whereas a `u8` can store values from 0 to 255.
 


### PR DESCRIPTION
The `u8` has a range [0 - 255], therefore the range is represented as [0 - 2^n - 1] where `n = 8`.